### PR TITLE
docs: typo fix Update _README.md

### DIFF
--- a/docs/_README.md
+++ b/docs/_README.md
@@ -39,7 +39,7 @@ This command generates static content into the `build` directory and can be serv
 
 ### General info
 
-You can see `warning` in time `pnpm install` - it's okey
+You can see `warning` in time `pnpm install` - it's okay
 
 File `docs\limit-order-protocol\smart-contract\_category_.json` changed after `pnpm install`. Discard changes in this file before execute some other commands
 


### PR DESCRIPTION
I noticed that the word "okey" was used in some parts of the documentation and code.
The correct spelling is "**okay**," so I’ve gone ahead and updated it to ensure proper spelling throughout. 