### PR TITLE
ci: fix deploy workflow pnpm/lockfile (restore production deploy)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -56,8 +56,8 @@ jobs:
 
       - name: Install pnpm and dependencies
         run: |
-          npm install -g pnpm@8.8.0
-          pnpm install
+          npm install -g pnpm@10
+          pnpm install --frozen-lockfile
 
       - name: Build production
         run: pnpm run build


### PR DESCRIPTION
## Summary

Production **Deploy** to Cloudflare Pages broke on `main` right after #43 merged. #43 fixed the same bug in `pr.yml` but `deploy.yaml` was missed — it still ran `pnpm@8.8.0` + non-frozen `pnpm install`, which can't read the v9 `pnpm-lock.yaml`, re-resolves to an incompatible `webpack`, and fails the `Build production` step with a `ProgressPlugin` `ValidationError`.

This applies the identical fix to `deploy.yaml`: `pnpm@10` + `pnpm install --frozen-lockfile`.

## Evidence

- Failed deploy run: https://github.com/1inch/community-web-ui/actions/runs/27404730463 (`Build production` → ValidationError; `Bump Version` / `pre-run` were fine)
- The CI `Build` (pr.yml) on `main` is already green after #43.

Closes #44

Made with [Cursor](https://cursor.com)