### PR TITLE
fix(security): pin websocket-driver >=0.7.5 (Dependabot #224)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
       "fast-xml-parser": ">=5.7.0",
       "serialize-javascript": ">=7.0.5",
       "shell-quote": ">=1.8.4",
-      "uuid": ">=11.1.1"
+      "uuid": ">=11.1.1",
+      "websocket-driver": ">=0.7.5"
     }
   },
   "browserslist": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   serialize-javascript: '>=7.0.5'
   shell-quote: '>=1.8.4'
   uuid: '>=11.1.1'
+  websocket-driver: '>=0.7.5'
 
 importers:
 


### PR DESCRIPTION
## Summary
- Fixes critical Dependabot alert [#224](https://github.com/1inch/community-web-ui/security/dependabot/224) (`websocket-driver`: message corruption via abused protocol length headers, CVE-2026-54466 / GHSA-xv26-6w52-cph6).
- Adds a `pnpm.overrides` pin for `websocket-driver: ">=0.7.5"` so the patched version stays resolved (transitive via `webpack-dev-server` → `sockjs` → `faye-websocket` / `sockjs`) and cannot regress to `< 0.7.5`.

## Test plan
- [x] `pnpm install`
- [x] `pnpm why websocket-driver` → only `0.7.5`
- [x] Confirmed no `websocket-driver@0.7.[0-4]` in `pnpm-lock.yaml`
- [x] `pnpm run build` succeeds
- [x] `pnpm start --port 3456 --host 127.0.0.1` boots and returns HTTP 200


Made with [Cursor](https://cursor.com)